### PR TITLE
Only check nodes which own part of the segment being proposed

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -366,13 +366,13 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
     try {
       final long startTime = System.currentTimeMillis();
       final long maxTime = startTime + timeoutMillis;
-      final long waitTime = Math.min(timeoutMillis, 60000);
+      final long waitTime = Math.min(timeoutMillis, 20000);
       long lastLoopTime = startTime;
 
       while (System.currentTimeMillis() < maxTime) {
         condition.await(waitTime, TimeUnit.MILLISECONDS);
 
-        boolean isDoneOrTimedOut = lastLoopTime + 60_000 > System.currentTimeMillis();
+        boolean isDoneOrTimedOut = lastLoopTime + waitTime > System.currentTimeMillis();
 
         isDoneOrTimedOut |= RepairSegment.State.DONE == context.storage
             .getRepairSegment(segment.getRunId(), segmentId).get().getState();


### PR DESCRIPTION
When Reaper is considering a segment for repair, it does some checks before it schedules the actual repair itself
- It checks if a segment that is part of this repair run is already running
- It checks if any nodes being coordinated by any segments that are part of the repair run are running repairs

The second check is flawed and results in a single segment being repaired at a time globally. This is definitely suboptimal especially with multiple keyspaces and leads to significant stacking of repairs and delays in the schedule.

So if a segment has a replication factor of 3, the tweak won't schedule any segments for any other repairs belonging to those 3 nodes. It's still slightly suboptimal (because we can schedule multiple keyspaces on the same three nodes) but far more optimal than a single repair globally.

For a 3 node cluster and replication factor of 3, we're not changing any behaviour here, however, for larger clusters, we'll be able to run in parallel a segment across multiple keyspaces.

With incremental repairs, the reason we have to run a single repair at a time is because of potential conflict between Compaction/ValidationCompaction and Anti-Compaction. This however doesn't matter when repairing multiple distinct keyspaces in parallel since SSTables are completely separate.

Cassandra Reaper 2.0 also has a similar fix to check for nodes which are actively part of the segment rather than the entire RepairRun itself