### PR TITLE
Don't abort unknown repairs

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -544,11 +544,10 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
 
               String msg = "Postponed due to affected hosts already doing repairs";
               repairRunner.updateLastEvent(msg);
-              handlePotentialStuckRepairs(busyHosts, metrics.getNode());
               return false;
             }
           }
-        } catch (InterruptedException | ExecutionException | ConcurrentException e) {
+        } catch (InterruptedException | ExecutionException e) {
           LOG.warn("Failed grabbing metrics from at least one node. Cannot repair segment :'(", e);
           allLocalDcHosts = false;
           allHosts = false;


### PR DESCRIPTION
Because we run multiple Reapers in parallel in the same cluster, the multiple Reapers are conflicting because they have repairs that the other does not know about. In full repair mode, Reaper tries to be a bit too smart and cancels all other repairs on the node if it spots a repair that it doesn't know about

This is definitely not ideal because it means incremental repairs constantly get cancelled and make less progress and duplicate work :(