### PR TITLE
Continue running repairs whilst we are making active progress

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -910,6 +910,13 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
           jmxProxy.removeRepairStatusHandler(repairNumber);
         }
         break;
+      case PROGRESS:
+        LOG.trace(
+            "Got progress {} for segment with id '{}' and repair number '{}'",
+            progress.get(),
+            segmentId,
+            repairNumber);
+        break;
       default:
         LOG.debug(
             "Unidentified progressStatus {} for segment with id '{}' and repair number '{}'",


### PR DESCRIPTION
The current control we have for repairs timing out is a bit too coarse. It imposes a global level timeout so even if we are making progress, if we hit the timeout, the segment gets cut off. Given the timeout is to detect hanging repairs, we can be smarter and have a renewable ticker with indication that after some time of no progress, we cut off the segment.

Our sign of progress is fed in from Cassandra itself so if it deems itself making progress, that's good enough for us.