### PR TITLE
Tweak our Repair and Segment runner to reduce sleeps between polling for repairs / segments

### DIFF
--- a/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/RepairRunner.java
@@ -486,7 +486,7 @@ final class RepairRunner implements Runnable {
       }
     } else {
       // Add random sleep time to avoid one Reaper instance locking all others during multi DC incremental repairs
-      Thread.sleep(ThreadLocalRandom.current().nextInt(0, 10 + 1) * 1000);
+      // Thread.sleep(ThreadLocalRandom.current().nextInt(0, 10 + 1) * 1000);
       potentialCoordinators
           = Arrays.asList(context.storage.getRepairSegment(repairRunId, segmentId).get().getCoordinatorHost());
     }

--- a/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
+++ b/src/server/src/main/java/io/cassandrareaper/service/SegmentRunner.java
@@ -83,7 +83,7 @@ final class SegmentRunner implements RepairStatusHandler, Runnable {
   private static final Pattern REPAIR_UUID_PATTERN
       = Pattern.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
 
-  private static final long SLEEP_TIME_AFTER_POSTPONE_IN_MS = 10000;
+  private static final long SLEEP_TIME_AFTER_POSTPONE_IN_MS = 2000;
   private static final ExecutorService METRICS_GRABBER_EXECUTOR = Executors.newFixedThreadPool(10);
   private static final long METRICS_POLL_INTERVAL_MS = TimeUnit.SECONDS.toMillis(10);
   private static final long METRICS_MAX_WAIT_MS = TimeUnit.MINUTES.toMillis(2);


### PR DESCRIPTION
When you have a lot of repairs / segments, this accumulates